### PR TITLE
Allow compilation on non-Windows platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@
 #![cfg_attr(feature="clippy", plugin(clippy))]
 #![cfg_attr(feature="clippy", warn(option_unwrap_used))]
 #![cfg_attr(feature="clippy", warn(result_unwrap_used))]
+#![cfg(windows)]
 extern crate winapi;
 extern crate kernel32;
 extern crate advapi32;


### PR DESCRIPTION
This effectively makes the crate a no-op on non-Windows platforms, in a similar manner to winapi-rs.
