### PR TITLE
add 'raw_handle' function and impl 'send' trait for 'RegKey'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,8 @@ pub struct RegKey {
     hkey: HKEY,
 }
 
+unsafe impl Send for RegKey {}
+
 impl RegKey {
     /// Open one of predefined keys:
     ///
@@ -206,6 +208,20 @@ impl RegKey {
     /// ```
     pub fn predef(hkey: HKEY) -> RegKey {
         RegKey{ hkey: hkey }
+    }
+
+    /// Return inner winapi HKEY of a key:
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use winreg::RegKey;
+    /// # use winreg::enums::*;
+    /// let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    /// let handle = hklm.raw_handle();
+    /// ```
+    pub fn raw_handle(&self) -> HKEY {
+        self.hkey
     }
 
     /// Open subkey with `KEY_READ` permissions.


### PR DESCRIPTION
I was wirting something like:
```
let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
let reg_key = hklm.open_subkey(r#"SOFTWARE\Microsoft\Windows\CurrentVersion"#).unwrap();

let handle = builder.spawn(move || {
    unsafe {
        let ret = RegNotifyChangeKeyValue(
            reg_key.raw_handle(),
            watch_subtree as i32,
            notify_filter,
            wait_handle.handle(),
            true as i32,
        );
        .....
    }
})?;
```
I thing add `raw_handle` function to `RegKey` allow us use `RegKey` in ffi programming. Since `winapi::shared::minwindef::HKEY` is a raw pointer, it should be fine to implement `send` trait for `RegKey`. 