### PR TITLE
add last_write_time to metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["Windows", "WinSDK", "Registry"]
 categories = ["api-bindings", "os::windows-apis"]
 
 [dependencies]
+chrono = { version = "0.4.6", optional = true }
 winapi = { version = "0.3", features = ["minwindef", "winerror", "winnt", "winreg", "handleapi"] }
 serde = { version = "1", optional = true }
 clippy = { version = "^0", optional = true }
@@ -22,6 +23,7 @@ serde_derive = "1"
 [features]
 transactions = ["winapi/ktmw32"]
 serialization-serde = ["transactions", "serde"]
+time-chrono = ["chrono", "winapi/minwinbase", "winapi/timezoneapi"]
 
 [[example]]
 name = "basic_usage"


### PR DESCRIPTION
i added a feature which brings in `chrono` and the `timezoneapi` and `minwinbase` from `winapi` to provide a little abstraction of the `FILETIME` object that windows provides. with the feature on it extends `RegKeyMetadata` structure to provide the `last_write_time` field. 

i also noticed when i opened the pr that `rustfmt` got hold of `lib.rs` and did some reformatting... i can definitely back out of that if you want.