### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -51,16 +51,7 @@ impl fmt::Display for DecoderError {
     }
 }
 
-impl Error for DecoderError {
-    fn description(&self) -> &str {
-        use self::DecoderError::*;
-        match *self {
-            DecodeNotImplemented(ref s) | DeserializerError(ref s) | ParseError(ref s) => s,
-            IoError(ref e) => e.description(),
-            NoFieldName => "No field name",
-        }
-    }
-}
+impl Error for DecoderError {}
 
 impl From<io::Error> for DecoderError {
     fn from(err: io::Error) -> DecoderError {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -46,16 +46,7 @@ impl fmt::Display for EncoderError {
     }
 }
 
-impl Error for EncoderError {
-    fn description(&self) -> &str {
-        use self::EncoderError::*;
-        match *self {
-            EncodeNotImplemented(ref s) | SerializerError(ref s) => s,
-            IoError(ref e) => e.description(),
-            NoFieldName => "No field name",
-        }
-    }
-}
+impl Error for EncoderError {}
 
 pub type EncodeResult<T> = Result<T, EncoderError>;
 


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon(1.42).

This PR:
- Removes an implementation of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919