### PR TITLE
Give a better error message when not compiling on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    if std::env::var("CARGO_CFG_WINDOWS").is_err() {
+        eprintln!("error: winreg is only supported on Windows platforms");
+        eprintln!(
+            "help: if your application is multi-platform, use \
+            `[target.'cfg(windows)'.dependencies] winreg = \"...\"`"
+        );
+        eprintln!("help: if your application is only supported on Windows, use `--target x86_64-pc-windows-gnu` or some other windows platform");
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
Before:

```
error[E0433]: failed to resolve: could not find `windows` in `os`
   --> src/lib.rs:121:14
    |
121 | use std::os::windows::ffi::OsStrExt;
    |              ^^^^^^^ could not find `windows` in `os`

error[E0433]: failed to resolve: could not find `shared` in `winapi`
   --> src/lib.rs:127:17
    |
127 | pub use winapi::shared::minwindef::HKEY;
    |                 ^^^^^^ could not find `shared` in `winapi`

... several dozen more errors ...
```

After:

```
$ cargo check
   Compiling winreg v0.7.0 (/home/joshua/src/rust/winreg-rs)
error: failed to run custom build command for `winreg v0.7.0 (/home/joshua/src/rust/winreg-rs)`

Caused by:
  process didn't exit successfully: `/home/joshua/.local/lib/cargo/target/debug/build/winreg-7bb8e6b8b363c511/build-script-build` (exit code: 1)
  --- stderr
  error: winreg is only supported on Windows platforms
  help: if your application is multi-platform, use `[target.'cfg(windows)'.dependencies] winreg = "..."`
  help: if your application is only supported on Windows, use `--target x86_64-pc-windows-gnu` or some other windows platform
```