### PR TITLE
Remove winapi dependency 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,25 @@ keywords = ["Windows", "WinSDK", "Registry"]
 categories = ["api-bindings", "os::windows-apis"]
 
 [dependencies]
-winapi = { version = "0.3.9", features = ["impl-default", "impl-debug", "minwindef", "minwinbase", "timezoneapi", "winerror", "winnt", "winreg", "handleapi"] }
+windows = {version = "0.44.0", features = [
+    "Win32_Foundation",
+    "Win32_System_Time",
+    "Win32_System_Registry",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_Debug"
+]}
+
 chrono = { version = "0.4.6", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
-tempfile = "~3.0"
+tempfile = "3.3.0"
 serde_derive = "1"
 
 [features]
-transactions = ["winapi/ktmw32"]
+transactions = []
 serialization-serde = ["transactions", "serde"]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ winreg = { version = "0.10", features = ["transactions"] }
 
 ```rust
 extern crate winreg;
+
 use std::io;
 use winreg::RegKey;
 use winreg::enums::*;
@@ -164,8 +165,7 @@ fn main() -> io::Result<()> {
     if input == "y" || input == "Y" {
         t.commit()?;
         println!("Transaction committed.");
-    }
-    else {
+    } else {
         // this is optional, if transaction wasn't committed,
         // it will be rolled back on disposal
         t.rollback()?;
@@ -282,14 +282,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ### 0.10.1
 
-* Bump minimal required version of `winapi` to `0.3.9` (required for `load_app_key`)
+* Bump the minimal required version of `winapi` to `0.3.9` (required for `load_app_key`)
 * Reexport `REG_PROCESS_APPKEY` and use it in the `load_app_key` example
 
 ### 0.10.0
 
 * Add `RegKey::load_app_key()` and `RegKey::load_app_key_with_flags()` ([#30](https://github.com/gentoo90/winreg-rs/issues/30))
 * Update dev dependency `rand` to `0.8`
-* Add Github actions
+* Add GitHub actions
 * Fix some clippy warnings
 
 ### 0.9.0
@@ -339,7 +339,7 @@ which can be `REG_CREATED_NEW_KEY` or `REG_OPENED_EXISTING_KEY` ([#21](https://g
 ### 0.5.0
 
 * Breaking change: `open_subkey` now opens a key with readonly permissions.
-Use `create_subkey` or `open_subkey_with_flags` to open with read-write permissins.
+Use `create_subkey` or `open_subkey_with_flags` to open with read-write permissions.
 * Breaking change: features `transactions` and `serialization-serde` are now disabled by default.
 * Breaking change: serialization now uses `serde` instead of `rustc-serialize`.
 * `winapi` updated to `0.3`.
@@ -348,7 +348,7 @@ Use `create_subkey` or `open_subkey_with_flags` to open with read-write permissi
 ### 0.4.0
 
 * Make transactions and serialization otional features
-* Update dependensies + minor fixes ([#12](https://github.com/gentoo90/winreg-rs/pull/12))
+* Update dependencies + minor fixes ([#12](https://github.com/gentoo90/winreg-rs/pull/12))
 
 ### 0.3.5
 
@@ -377,5 +377,5 @@ Use `create_subkey` or `open_subkey_with_flags` to open with read-write permissi
 
 ### 0.3.0
 
-* Add transactions support and make serialization transacted
+* Add `transactions` support and make serialization transacted
 * Breaking change: use `std::io::{Error,Result}` instead of own `RegError` and `RegResult`

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -15,12 +15,12 @@ fn main() -> io::Result<()> {
         .map(|x| x.unwrap())
         .filter(|x| x.starts_with('.'))
     {
-        println!("{}", i);
+        println!("{i}");
     }
 
     let system = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey("HARDWARE\\DESCRIPTION\\System")?;
     for (name, value) in system.enum_values().map(|x| x.unwrap()) {
-        println!("{} = {:?}", name, value);
+        println!("{name} = {value:?}");
     }
 
     Ok(())

--- a/examples/load_app_key.rs
+++ b/examples/load_app_key.rs
@@ -18,7 +18,7 @@ fn main() -> io::Result<()> {
     let answer: u32 = {
         // NOTE: on Windows 7 this fails with ERROR_ALREADY_EXISTS
         let app_key_2 =
-            RegKey::load_app_key_with_flags("myhive.dat", KEY_READ, REG_PROCESS_APPKEY)?;
+            RegKey::load_app_key_with_flags("myhive.dat", KEY_READ.0, REG_PROCESS_APPKEY)?;
         app_key_2.get_value("answer")?
     };
     println!("The Answer is {}", answer);

--- a/examples/load_app_key.rs
+++ b/examples/load_app_key.rs
@@ -21,6 +21,6 @@ fn main() -> io::Result<()> {
             RegKey::load_app_key_with_flags("myhive.dat", KEY_READ.0, REG_PROCESS_APPKEY)?;
         app_key_2.get_value("answer")?
     };
-    println!("The Answer is {}", answer);
+    println!("The Answer is {answer}");
     Ok(())
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -8,7 +8,9 @@ use super::RegKey;
 use std::error::Error;
 use std::fmt;
 use std::io;
-use winapi::shared::minwindef::DWORD;
+use windows::Win32::System::Registry::REG_SAM_FLAGS;
+
+type DWORD = u32;
 
 macro_rules! read_value {
     ($s:ident) => {
@@ -81,11 +83,9 @@ pub struct Decoder {
     enumeration_state: DecoderEnumerationState,
 }
 
-const DECODER_SAM: DWORD = KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS;
-
 impl Decoder {
     pub fn from_key(key: &RegKey) -> DecodeResult<Decoder> {
-        key.open_subkey_with_flags("", DECODER_SAM)
+        key.open_subkey_with_flags("", KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS)
             .map(Decoder::new)
             .map_err(DecoderError::IoError)
     }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -10,7 +10,9 @@ use super::RegKey;
 use std::error::Error;
 use std::fmt;
 use std::io;
-use winapi::shared::minwindef::DWORD;
+use windows::Win32::System::Registry::REG_SAM_FLAGS;
+
+type DWORD = u32;
 
 macro_rules! emit_value {
     ($s:ident, $v:ident) => {
@@ -71,12 +73,10 @@ pub struct Encoder {
     state: EncoderState,
 }
 
-const ENCODER_SAM: DWORD = KEY_CREATE_SUB_KEY | KEY_SET_VALUE;
-
 impl Encoder {
     pub fn from_key(key: &RegKey) -> EncodeResult<Encoder> {
         let tr = Transaction::new()?;
-        key.open_subkey_transacted_with_flags("", &tr, ENCODER_SAM)
+        key.open_subkey_transacted_with_flags("", &tr, KEY_CREATE_SUB_KEY | KEY_SET_VALUE)
             .map(|k| Encoder::new(k, tr))
             .map_err(EncoderError::IoError)
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -5,25 +5,24 @@
 // except according to those terms.
 
 //! `use winreg::enums::*;` to import all needed enumerations and constants
-use super::winapi;
-pub use winapi::um::winnt::{
-    KEY_ALL_ACCESS, KEY_CREATE_LINK, KEY_CREATE_SUB_KEY, KEY_ENUMERATE_SUB_KEYS, KEY_EXECUTE,
-    KEY_NOTIFY, KEY_QUERY_VALUE, KEY_READ, KEY_SET_VALUE, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
-    KEY_WOW64_RES, KEY_WRITE,
-};
-pub use winapi::um::winreg::{
+pub use windows::Win32::System::Registry::{
     HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
     HKEY_DYN_DATA, HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_PERFORMANCE_NLSTEXT,
     HKEY_PERFORMANCE_TEXT, HKEY_USERS, REG_PROCESS_APPKEY,
 };
+pub use windows::Win32::System::Registry::{
+    KEY_ALL_ACCESS, KEY_CREATE_LINK, KEY_CREATE_SUB_KEY, KEY_ENUMERATE_SUB_KEYS, KEY_EXECUTE,
+    KEY_NOTIFY, KEY_QUERY_VALUE, KEY_READ, KEY_SET_VALUE, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
+    KEY_WOW64_RES, KEY_WRITE,
+};
 
-macro_rules! winapi_enum{
+macro_rules! winapi_enum {
     ($t:ident, $doc:expr => [$($v:ident),*]) => (
         #[doc=$doc]
         #[allow(non_camel_case_types)]
         #[derive(Debug,Clone,PartialEq)]
         pub enum $t {
-            $( $v = winapi::um::winnt::$v as isize ),*
+            $( $v = windows::Win32::System::Registry::$v.0 as isize ),*
         }
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,14 +131,14 @@ use std::slice;
 use transaction::Transaction;
 use types::{FromRegValue, ToRegValue};
 use windows::core::{PCWSTR, PWSTR};
-use windows::Win32::Foundation;
+
 use windows::Win32::Foundation as winerror;
+use windows::Win32::Foundation::FILETIME;
 use windows::Win32::Foundation::SYSTEMTIME;
-use windows::Win32::Foundation::{FILETIME, WIN32_ERROR};
 use windows::Win32::System::Registry as winapi_reg;
 use windows::Win32::System::Registry as winnt;
 pub use windows::Win32::System::Registry::HKEY;
-use windows::Win32::System::Registry::{REG_CREATE_KEY_DISPOSITION, REG_SAM_FLAGS, REG_VALUE_TYPE};
+use windows::Win32::System::Registry::{REG_CREATE_KEY_DISPOSITION, REG_VALUE_TYPE};
 use windows::Win32::System::Time::FileTimeToSystemTime;
 type BYTE = u8;
 type DWORD = u32;
@@ -222,7 +222,7 @@ impl fmt::Display for RegValue {
             REG_QWORD => format_reg_value!(self => u64),
             _ => format!("{:?}", self.bytes), //TODO: implement more types
         };
-        write!(f, "{}", f_val)
+        write!(f, "{f_val}")
     }
 }
 
@@ -798,7 +798,7 @@ impl RegKey {
     pub fn get_raw_value<N: AsRef<OsStr>>(&self, name: N) -> io::Result<RegValue> {
         let c_name = to_utf16(name);
         let mut buf_len: DWORD = 2048;
-        let mut buf_type: DWORD = 0;
+        let buf_type: DWORD = 0;
         let mut buf: Vec<u8> = Vec::with_capacity(buf_len as usize);
         loop {
             match unsafe {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -41,9 +41,10 @@
 #![cfg(feature = "transactions")]
 use std::io;
 use std::ptr;
-use winapi::um::handleapi;
-use winapi::um::ktmw32;
-use winapi::um::winnt;
+use windows::core::PCWSTR;
+use windows::Win32::Foundation as handleapi;
+use windows::Win32::Foundation as winnt;
+use windows::Win32::Storage::FileSystem as ktmw32;
 
 #[derive(Debug)]
 pub struct Transaction {
@@ -61,8 +62,10 @@ impl Transaction {
                 0,
                 0,
                 0,
-                ptr::null_mut(),
-            );
+                PCWSTR::null(),
+            )
+            .ok()
+            .unwrap();
             if handle == handleapi::INVALID_HANDLE_VALUE {
                 return Err(io::Error::last_os_error());
             };
@@ -72,7 +75,7 @@ impl Transaction {
 
     pub fn commit(&self) -> io::Result<()> {
         unsafe {
-            match ktmw32::CommitTransaction(self.handle) {
+            match ktmw32::CommitTransaction(self.handle).0 {
                 0 => Err(io::Error::last_os_error()),
                 _ => Ok(()),
             }
@@ -81,7 +84,7 @@ impl Transaction {
 
     pub fn rollback(&self) -> io::Result<()> {
         unsafe {
-            match ktmw32::RollbackTransaction(self.handle) {
+            match ktmw32::RollbackTransaction(self.handle).0 {
                 0 => Err(io::Error::last_os_error()),
                 _ => Ok(()),
             }
@@ -90,7 +93,7 @@ impl Transaction {
 
     fn close_(&mut self) -> io::Result<()> {
         unsafe {
-            match handleapi::CloseHandle(self.handle) {
+            match handleapi::CloseHandle(self.handle).0 {
                 0 => Err(io::Error::last_os_error()),
                 _ => Ok(()),
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@
 
 //! Traits for loading/saving Registry values
 use super::enums::*;
-use super::winapi::shared::winerror;
+use super::windows::Win32::Foundation as winerror;
 use super::RegValue;
 use super::{to_utf16, v16_to_v8};
 use std::ffi::{OsStr, OsString};

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,7 +39,7 @@ impl FromRegValue for String {
                     s.pop();
                 }
                 if val.vtype == REG_MULTI_SZ {
-                    return Ok(s.replace("\u{0}", "\n"));
+                    return Ok(s.replace('\u{0}', "\n"));
                 }
                 Ok(s)
             }
@@ -98,7 +98,7 @@ impl FromRegValue for Vec<OsString> {
                 }
                 let v: Vec<OsString> = words
                     .split(|ch| *ch == 0u16)
-                    .map(|x| OsString::from_wide(x))
+                    .map(OsString::from_wide)
                     .collect();
                 Ok(v)
             }

--- a/tests/reg_key.rs
+++ b/tests/reg_key.rs
@@ -73,7 +73,7 @@ fn test_create_subkey_disposition() {
     assert_eq!(disp, REG_CREATED_NEW_KEY);
     let (_subkey2, disp2) = hkcu.create_subkey(path).unwrap();
     assert_eq!(disp2, REG_OPENED_EXISTING_KEY);
-    hkcu.delete_subkey_all(&path).unwrap();
+    hkcu.delete_subkey_all(path).unwrap();
 }
 
 macro_rules! with_key {
@@ -272,7 +272,7 @@ fn test_enum_long_values() {
         let mut vals = HashMap::with_capacity(3);
 
         for i in &[5500, 9500, 15000] {
-            let name: String = format!("val{}", i);
+            let name: String = format!("val{i}");
             let val = RegValue { vtype: REG_BINARY, bytes: (0..*i).map(|_| rand::random::<u8>()).collect() };
             vals.insert(name, val);
         }

--- a/tests/reg_key.rs
+++ b/tests/reg_key.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 extern crate tempfile;
-extern crate winapi;
+extern crate windows;
 extern crate winreg;
 #[cfg(feature = "serialization-serde")]
 #[macro_use]
@@ -9,7 +9,7 @@ use self::rand::Rng;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use tempfile::tempdir;
-use winapi::shared::winerror;
+use windows::Win32::Foundation as winerror;
 use winreg::enums::*;
 use winreg::types::FromRegValue;
 use winreg::{RegKey, RegValue};
@@ -31,15 +31,15 @@ fn test_load_appkey() {
         let key1 = RegKey::load_app_key(&file_path, true).unwrap();
         key1.set_value(val_name, &val1).unwrap();
         // this fails on Windows 7 with ERROR_ALREADY_EXISTS
-        let key_err = RegKey::load_app_key_with_flags(&file_path, KEY_READ, 0).unwrap_err();
+        let key_err = RegKey::load_app_key_with_flags(&file_path, KEY_READ.0, 0).unwrap_err();
         assert_eq!(
             key_err.raw_os_error(),
-            Some(winerror::ERROR_SHARING_VIOLATION as i32)
+            Some(winerror::ERROR_SHARING_VIOLATION.0 as i32)
         );
     }
     let val2: String = {
         // this fails on Windows 7 with ERROR_ALREADY_EXISTS
-        let key2 = RegKey::load_app_key_with_flags(&file_path, KEY_READ, 1).unwrap();
+        let key2 = RegKey::load_app_key_with_flags(&file_path, KEY_READ.0, 1).unwrap();
         key2.get_value(val_name).unwrap()
     };
     assert_eq!(val1, val2);
@@ -106,7 +106,7 @@ fn test_delete_subkey_with_flags() {
         .create_subkey_with_flags(path, KEY_WOW64_32KEY)
         .unwrap();
     assert!(RegKey::predef(HKEY_CURRENT_USER)
-        .delete_subkey_with_flags(path, KEY_WOW64_32KEY)
+        .delete_subkey_with_flags(path, KEY_WOW64_32KEY.0)
         .is_ok());
 }
 


### PR DESCRIPTION
I am attempting to update the codebase to utilize [`windows-rs`](https://github.com/microsoft/windows-rs) instead of `winapi`. While the build is successful, some tests are currently failing with the error message `code: 222, kind: Uncategorized, message: "The file type being saved or retrieved has been blocked."`. ~I am currently investigating ways to resolve these issues.~