### PR TITLE
remove winapi dependency, upgrade edition and replace decrypted APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,24 @@ keywords = ["Windows", "WinSDK", "Registry"]
 categories = ["api-bindings", "os::windows-apis"]
 
 [dependencies]
-winapi = { version = "0.3.9", features = ["impl-default", "impl-debug", "minwindef", "minwinbase", "timezoneapi", "winerror", "winnt", "winreg", "handleapi"] }
+windows-sys = {version = "0.45.0", features = [
+    "Win32_Foundation",
+    "Win32_System_Time",
+    "Win32_System_Registry",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_Debug"
+]}
 chrono = { version = "0.4.6", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
-tempfile = "~3.0"
+tempfile = "3.3.0"
 serde_derive = "1"
 
 [features]
-transactions = ["winapi/ktmw32"]
+transactions = []
 serialization-serde = ["transactions", "serde"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "winreg"
 version = "0.10.1"
 authors = ["Igor Shaula <gentoo90@gmail.com>"]
 license = "MIT"
+edition = "2021"
 description = "Rust bindings to MS Windows Registry API"
 repository = "https://github.com/gentoo90/winreg-rs"
 documentation = "https://docs.rs/winreg"

--- a/README.md
+++ b/README.md
@@ -282,14 +282,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 ### 0.10.1
 
-* Bump minimal required version of `winapi` to `0.3.9` (required for `load_app_key`)
+* Bump the minimal required version of `winapi` to `0.3.9` (required for `load_app_key`)
 * Reexport `REG_PROCESS_APPKEY` and use it in the `load_app_key` example
 
 ### 0.10.0
 
 * Add `RegKey::load_app_key()` and `RegKey::load_app_key_with_flags()` ([#30](https://github.com/gentoo90/winreg-rs/issues/30))
 * Update dev dependency `rand` to `0.8`
-* Add Github actions
+* Add GitHub actions
 * Fix some clippy warnings
 
 ### 0.9.0
@@ -377,5 +377,5 @@ Use `create_subkey` or `open_subkey_with_flags` to open with read-write permissi
 
 ### 0.3.0
 
-* Add transactions support and make serialization transacted
+* Add transaction support and make serialization transacted
 * Breaking change: use `std::io::{Error,Result}` instead of own `RegError` and `RegResult`

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -12,14 +12,14 @@ fn main() -> io::Result<()> {
     println!("File extensions, registered in system:");
     for i in RegKey::predef(HKEY_CLASSES_ROOT)
         .enum_keys()
-        .map(std::result::Result::unwrap)
+        .map(Result::unwrap)
         .filter(|x| x.starts_with('.'))
     {
         println!("{i}");
     }
 
     let system = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey("HARDWARE\\DESCRIPTION\\System")?;
-    for (name, value) in system.enum_values().map(std::result::Result::unwrap) {
+    for (name, value) in system.enum_values().map(Result::unwrap) {
         println!("{name} = {value:?}");
     }
 

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -5,22 +5,22 @@
 // except according to those terms.
 extern crate winreg;
 use std::io;
-use winreg::enums::*;
+use winreg::enums::{HKEY_CLASSES_ROOT, HKEY_LOCAL_MACHINE};
 use winreg::RegKey;
 
 fn main() -> io::Result<()> {
     println!("File extensions, registered in system:");
     for i in RegKey::predef(HKEY_CLASSES_ROOT)
         .enum_keys()
-        .map(|x| x.unwrap())
+        .map(std::result::Result::unwrap)
         .filter(|x| x.starts_with('.'))
     {
-        println!("{}", i);
+        println!("{i}");
     }
 
     let system = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey("HARDWARE\\DESCRIPTION\\System")?;
-    for (name, value) in system.enum_values().map(|x| x.unwrap()) {
-        println!("{} = {:?}", name, value);
+    for (name, value) in system.enum_values().map(std::result::Result::unwrap) {
+        println!("{name} = {value:?}");
     }
 
     Ok(())

--- a/examples/load_app_key.rs
+++ b/examples/load_app_key.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 extern crate winreg;
 use std::io;
-use winreg::enums::*;
+use winreg::enums::{KEY_READ, REG_PROCESS_APPKEY};
 use winreg::RegKey;
 
 fn main() -> io::Result<()> {
@@ -21,6 +21,6 @@ fn main() -> io::Result<()> {
             RegKey::load_app_key_with_flags("myhive.dat", KEY_READ, REG_PROCESS_APPKEY)?;
         app_key_2.get_value("answer")?
     };
-    println!("The Answer is {}", answer);
+    println!("The Answer is {answer}");
     Ok(())
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -8,7 +8,8 @@ use super::RegKey;
 use std::error::Error;
 use std::fmt;
 use std::io;
-use winapi::shared::minwindef::DWORD;
+
+type DWORD = u32;
 
 macro_rules! read_value {
     ($s:ident) => {

--- a/src/decoder/serialization_serde.rs
+++ b/src/decoder/serialization_serde.rs
@@ -29,7 +29,7 @@ impl<'de, 'a> Deserializer<'de> for &'a mut Decoder {
             EnumeratingValues(..) => {
                 let s = self.f_name.as_ref().ok_or(DecoderError::NoFieldName)?;
                 let v = self.key.get_raw_value(s)?;
-                use RegType::*;
+                use crate::RegType::*;
                 match v.vtype {
                     REG_SZ | REG_EXPAND_SZ | REG_MULTI_SZ => {
                         visitor.visit_string(String::from_reg_value(&v)?)

--- a/src/decoder/serialization_serde.rs
+++ b/src/decoder/serialization_serde.rs
@@ -51,34 +51,6 @@ impl<'de, 'a> Deserializer<'de> for &'a mut Decoder {
         visitor.visit_bool(read_value!(self).map(|v: u32| v > 0)?)
     }
 
-    fn deserialize_u8<V>(self, visitor: V) -> DecodeResult<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_u32(visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> DecodeResult<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_u32(visitor)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> DecodeResult<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u32(read_value!(self)?)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> DecodeResult<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_u64(read_value!(self)?)
-    }
-
     fn deserialize_i8<V>(self, visitor: V) -> DecodeResult<V::Value>
     where
         V: Visitor<'de>,
@@ -105,6 +77,34 @@ impl<'de, 'a> Deserializer<'de> for &'a mut Decoder {
         V: Visitor<'de>,
     {
         visitor.visit_i64(parse_string!(self)?)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u32(visitor)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_u32(visitor)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u32(read_value!(self)?)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_u64(read_value!(self)?)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> DecodeResult<V::Value>
@@ -247,13 +247,6 @@ impl<'de, 'a> Deserializer<'de> for &'a mut Decoder {
         visitor.visit_map(self)
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> DecodeResult<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_string(visitor)
-    }
-
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -264,6 +257,13 @@ impl<'de, 'a> Deserializer<'de> for &'a mut Decoder {
         V: Visitor<'de>,
     {
         no_impl!("deserialize_enum")
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> DecodeResult<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> DecodeResult<V::Value>

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -10,7 +10,8 @@ use super::RegKey;
 use std::error::Error;
 use std::fmt;
 use std::io;
-use winapi::shared::minwindef::DWORD;
+
+type DWORD = u32;
 
 macro_rules! emit_value {
     ($s:ident, $v:ident) => {

--- a/src/encoder/serialization_serde.rs
+++ b/src/encoder/serialization_serde.rs
@@ -266,7 +266,7 @@ impl SerializeTupleVariant for TupleVariantEncoder {
 
 struct MapKeySerializer;
 
-impl serde::Serializer for MapKeySerializer {
+impl Serializer for MapKeySerializer {
     type Ok = String;
     type Error = EncoderError;
 
@@ -277,24 +277,6 @@ impl serde::Serializer for MapKeySerializer {
     type SerializeMap = Impossible<String, EncoderError>;
     type SerializeStruct = Impossible<String, EncoderError>;
     type SerializeStructVariant = Impossible<String, EncoderError>;
-
-    #[inline]
-    fn serialize_unit_variant(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        variant: &'static str,
-    ) -> EncodeResult<Self::Ok> {
-        Ok(variant.to_owned())
-    }
-
-    #[inline]
-    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> EncodeResult<Self::Ok>
-    where
-        T: ?Sized + Serialize,
-    {
-        value.serialize(self)
-    }
 
     fn serialize_bool(self, _value: bool) -> EncodeResult<Self::Ok> {
         Err(EncoderError::KeyMustBeAString)
@@ -358,12 +340,41 @@ impl serde::Serializer for MapKeySerializer {
         Err(EncoderError::KeyMustBeAString)
     }
 
+    fn serialize_none(self) -> EncodeResult<Self::Ok> {
+        Err(EncoderError::KeyMustBeAString)
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> EncodeResult<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(EncoderError::KeyMustBeAString)
+    }
+
     fn serialize_unit(self) -> EncodeResult<Self::Ok> {
         Err(EncoderError::KeyMustBeAString)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> EncodeResult<Self::Ok> {
         Err(EncoderError::KeyMustBeAString)
+    }
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> EncodeResult<Self::Ok> {
+        Ok(variant.to_owned())
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> EncodeResult<Self::Ok>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
     }
 
     fn serialize_newtype_variant<T>(
@@ -373,17 +384,6 @@ impl serde::Serializer for MapKeySerializer {
         _variant: &'static str,
         _value: &T,
     ) -> EncodeResult<Self::Ok>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(EncoderError::KeyMustBeAString)
-    }
-
-    fn serialize_none(self) -> EncodeResult<Self::Ok> {
-        Err(EncoderError::KeyMustBeAString)
-    }
-
-    fn serialize_some<T>(self, _value: &T) -> EncodeResult<Self::Ok>
     where
         T: ?Sized + Serialize,
     {

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -5,16 +5,15 @@
 // except according to those terms.
 
 //! `use winreg::enums::*;` to import all needed enumerations and constants
-use super::winapi;
-pub use winapi::um::winnt::{
-    KEY_ALL_ACCESS, KEY_CREATE_LINK, KEY_CREATE_SUB_KEY, KEY_ENUMERATE_SUB_KEYS, KEY_EXECUTE,
-    KEY_NOTIFY, KEY_QUERY_VALUE, KEY_READ, KEY_SET_VALUE, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
-    KEY_WOW64_RES, KEY_WRITE,
-};
-pub use winapi::um::winreg::{
+pub use windows_sys::Win32::System::Registry::{
     HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_CURRENT_USER_LOCAL_SETTINGS,
     HKEY_DYN_DATA, HKEY_LOCAL_MACHINE, HKEY_PERFORMANCE_DATA, HKEY_PERFORMANCE_NLSTEXT,
     HKEY_PERFORMANCE_TEXT, HKEY_USERS, REG_PROCESS_APPKEY,
+};
+pub use windows_sys::Win32::System::Registry::{
+    KEY_ALL_ACCESS, KEY_CREATE_LINK, KEY_CREATE_SUB_KEY, KEY_ENUMERATE_SUB_KEYS, KEY_EXECUTE,
+    KEY_NOTIFY, KEY_QUERY_VALUE, KEY_READ, KEY_SET_VALUE, KEY_WOW64_32KEY, KEY_WOW64_64KEY,
+    KEY_WOW64_RES, KEY_WRITE,
 };
 
 macro_rules! winapi_enum{
@@ -23,7 +22,7 @@ macro_rules! winapi_enum{
         #[allow(non_camel_case_types)]
         #[derive(Debug,Clone,PartialEq)]
         pub enum $t {
-            $( $v = winapi::um::winnt::$v as isize ),*
+            $( $v = windows_sys::Win32::System::Registry::$v as isize ),*
         }
     )
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -9,13 +9,15 @@
 //!
 //!```no_run
 //!extern crate winreg;
+//!extern crate windows_sys;
 //!use std::io;
 //!use winreg::RegKey;
 //!use winreg::enums::*;
 //!use winreg::transaction::Transaction;
 //!
 //!fn main() {
-//!    let t = Transaction::new().unwrap();
+//!    use windows_sys::Win32::System::Registry::HKEY_CURRENT_USER;
+//! let t = Transaction::new().unwrap();
 //!    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
 //!    let (key, _disp) = hkcu.create_subkey_transacted("Software\\RustTransaction", &t).unwrap();
 //!    key.set_value("TestQWORD", &1234567891011121314u64).unwrap();
@@ -41,9 +43,9 @@
 #![cfg(feature = "transactions")]
 use std::io;
 use std::ptr;
-use winapi::um::handleapi;
-use winapi::um::ktmw32;
-use winapi::um::winnt;
+use windows_sys::Win32::Foundation as handleapi;
+use windows_sys::Win32::Foundation as winnt;
+use windows_sys::Win32::Storage::FileSystem as ktmw32;
 
 #[derive(Debug)]
 pub struct Transaction {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -26,7 +26,7 @@
 //!    println!("Commit transaction? [y/N]:");
 //!    let mut input = String::new();
 //!    io::stdin().read_line(&mut input).unwrap();
-//!    input = input.trim_right().to_owned();
+//!    input = input.trim_end().to_owned();
 //!    if input == "y" || input == "Y" {
 //!        t.commit().unwrap();
 //!        println!("Transaction committed.");

--- a/tests/reg_key.rs
+++ b/tests/reg_key.rs
@@ -1,6 +1,6 @@
 extern crate rand;
 extern crate tempfile;
-extern crate winapi;
+extern crate windows_sys;
 extern crate winreg;
 #[cfg(feature = "serialization-serde")]
 #[macro_use]
@@ -9,8 +9,11 @@ use self::rand::Rng;
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use tempfile::tempdir;
-use winapi::shared::winerror;
-use winreg::enums::*;
+use windows_sys::Win32::Foundation as winerror;
+use winreg::enums::{
+    HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ, KEY_WOW64_32KEY, REG_BINARY,
+    REG_CREATED_NEW_KEY, REG_OPENED_EXISTING_KEY,
+};
 use winreg::types::FromRegValue;
 use winreg::{RegKey, RegValue};
 
@@ -73,7 +76,7 @@ fn test_create_subkey_disposition() {
     assert_eq!(disp, REG_CREATED_NEW_KEY);
     let (_subkey2, disp2) = hkcu.create_subkey(path).unwrap();
     assert_eq!(disp2, REG_OPENED_EXISTING_KEY);
-    hkcu.delete_subkey_all(&path).unwrap();
+    hkcu.delete_subkey_all(path).unwrap();
 }
 
 macro_rules! with_key {
@@ -240,7 +243,7 @@ fn test_enum_keys() {
         for i in &keys1 {
             key.create_subkey(i).unwrap();
         }
-        let keys2: Vec<_> = key.enum_keys().map(|x| x.unwrap()).collect();
+        let keys2: Vec<_> = key.enum_keys().map(std::result::Result::unwrap).collect();
         assert_eq!(keys1, keys2);
     });
 }
@@ -256,7 +259,7 @@ fn test_enum_values() {
         let mut vals2: Vec<String> = Vec::with_capacity(vals1.len());
         let mut vals3: Vec<String> = Vec::with_capacity(vals1.len());
         for (name, val) in key.enum_values()
-            .map(|x| x.unwrap())
+            .map(std::result::Result::unwrap)
         {
             vals2.push(name);
             vals3.push(String::from_reg_value(&val).unwrap());
@@ -272,13 +275,13 @@ fn test_enum_long_values() {
         let mut vals = HashMap::with_capacity(3);
 
         for i in &[5500, 9500, 15000] {
-            let name: String = format!("val{}", i);
+            let name: String = format!("val{i}");
             let val = RegValue { vtype: REG_BINARY, bytes: (0..*i).map(|_| rand::random::<u8>()).collect() };
             vals.insert(name, val);
         }
 
         for (name, val) in key.enum_values()
-                              .map(|x| x.unwrap())
+                              .map(std::result::Result::unwrap)
         {
             assert_eq!(val.bytes, vals[&name].bytes);
         }

--- a/tests/reg_key.rs
+++ b/tests/reg_key.rs
@@ -56,7 +56,7 @@ fn test_open_subkey_with_flags_query_info() {
         .unwrap();
 
     let info = win.query_info().unwrap();
-    info.get_last_write_time_system();
+    let _ = info.get_last_write_time_system();
     #[cfg(feature = "chrono")]
     info.get_last_write_time_chrono();
 


### PR DESCRIPTION
I am attempting to update the codebase to utilize [`windows-rs`](https://github.com/microsoft/windows-rs) instead of `winapi`. While the build is successful, 1 test is currently failing with the error message ``thread 'test_load_appkey' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: Uncategorized, message: "The process cannot access the file because it is being used by another process." }', tests\reg_key.rs:45:77``.