### PR TITLE
Implement RegKey::encode_transacted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ name = "serialization"
 required-features = ["serialization-serde"]
 
 [[example]]
+name = "transacted_serialization"
+required-features = ["serialization-serde"]
+
+[[example]]
 name = "map_key_serialization"
 required-features = ["serialization-serde"]
 

--- a/examples/transacted_serialization.rs
+++ b/examples/transacted_serialization.rs
@@ -1,0 +1,99 @@
+// Copyright 2023, Igor Shaula
+// Licensed under the MIT License <LICENSE or
+// http://opensource.org/licenses/MIT>. This file
+// may not be copied, modified, or distributed
+// except according to those terms.
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use winreg::enums::*;
+use winreg::transaction::Transaction;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Coords {
+    x: u32,
+    y: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Size {
+    w: u32,
+    h: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Rectangle {
+    coords: Coords,
+    size: Size,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Test {
+    t_bool: bool,
+    t_u8: u8,
+    t_u16: u16,
+    t_u32: u32,
+    t_u64: u64,
+    t_usize: usize,
+    t_struct: Rectangle,
+    t_map: HashMap<String, u32>,
+    t_string: String,
+    #[serde(with = "serde_bytes")]
+    t_bytes: Vec<u8>,
+    #[serde(rename = "")] // empty name becomes the (Default) value in the registry
+    t_char: char,
+    t_i8: i8,
+    t_i16: i16,
+    t_i32: i32,
+    t_i64: i64,
+    t_isize: isize,
+    t_f64: f64,
+    t_f32: f32,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let transaction = Transaction::new()?;
+    let hkcu = winreg::RegKey::predef(HKEY_CURRENT_USER);
+    let (key, _disp) = hkcu.create_subkey_transacted("Software\\RustEncode", &transaction)?;
+
+    let mut map = HashMap::new();
+    map.insert("".to_owned(), 0); // empty name becomes the (Default) value in the registry
+    map.insert("v1".to_owned(), 1);
+    map.insert("v2".to_owned(), 2);
+    map.insert("v3".to_owned(), 3);
+
+    let v1 = Test {
+        t_bool: false,
+        t_u8: 127,
+        t_u16: 32768,
+        t_u32: 123_456_789,
+        t_u64: 123_456_789_101_112,
+        t_usize: 1_234_567_891,
+        t_struct: Rectangle {
+            coords: Coords { x: 55, y: 77 },
+            size: Size { w: 500, h: 300 },
+        },
+        t_map: map,
+        t_string: "test 123!".to_owned(),
+        t_bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        t_char: 'a',
+        t_i8: -123,
+        t_i16: -2049,
+        t_i32: 20100,
+        t_i64: -12_345_678_910,
+        t_isize: -1_234_567_890,
+        t_f64: -0.01,
+        t_f32: 3.15,
+    };
+
+    key.encode_transacted(&v1, &transaction).unwrap();
+    transaction.commit().unwrap();
+
+    let key = hkcu.open_subkey("Software\\RustEncode")?;
+
+    let v2: Test = key.decode().unwrap();
+    println!("Decoded {:?}", v2);
+
+    println!("Equal to encoded: {:?}", v1 == v2);
+    Ok(())
+}

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -64,23 +64,23 @@ enum EncoderState {
 }
 
 #[derive(Debug)]
-pub struct Encoder {
+pub struct Encoder<Tr: AsRef<Transaction>> {
     keys: Vec<RegKey>,
-    tr: Transaction,
+    tr: Tr,
     state: EncoderState,
 }
 
 const ENCODER_SAM: u32 = KEY_CREATE_SUB_KEY | KEY_SET_VALUE;
 
-impl Encoder {
-    pub fn from_key(key: &RegKey) -> EncodeResult<Encoder> {
+impl Encoder<Transaction> {
+    pub fn from_key(key: &RegKey) -> EncodeResult<Encoder<Transaction>> {
         let tr = Transaction::new()?;
         key.open_subkey_transacted_with_flags("", &tr, ENCODER_SAM)
             .map(|k| Encoder::new(k, tr))
             .map_err(EncoderError::IoError)
     }
 
-    fn new(key: RegKey, tr: Transaction) -> Encoder {
+    fn new(key: RegKey, tr: Transaction) -> Encoder<Transaction> {
         let mut keys = Vec::with_capacity(5);
         keys.push(key);
         Encoder {
@@ -92,5 +92,26 @@ impl Encoder {
 
     pub fn commit(&mut self) -> EncodeResult<()> {
         self.tr.commit().map_err(EncoderError::IoError)
+    }
+}
+
+impl Encoder<&Transaction> {
+    pub fn from_key_transacted<'a>(
+        key: &RegKey,
+        tr: &'a Transaction,
+    ) -> EncodeResult<Encoder<&'a Transaction>> {
+        key.open_subkey_transacted_with_flags("", &tr, ENCODER_SAM)
+            .map(|k| Encoder::new_transacted(k, tr))
+            .map_err(EncoderError::IoError)
+    }
+
+    fn new_transacted(key: RegKey, tr: &Transaction) -> Encoder<&Transaction> {
+        let mut keys = Vec::with_capacity(5);
+        keys.push(key);
+        Encoder {
+            keys,
+            tr,
+            state: Start,
+        }
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -101,3 +101,9 @@ impl Drop for Transaction {
         self.close_().unwrap_or(());
     }
 }
+
+impl AsRef<Transaction> for Transaction {
+    fn as_ref(&self) -> &Transaction {
+        self
+    }
+}

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -132,3 +132,29 @@ fn test_serialization_all() {
         assert_eq!(v2, v1);
     });
 }
+
+#[test]
+fn test_serialization_some_transacted() {
+    let v1 = AllFields::test_val();
+
+    with_key!(key, "SerializationSomeTransacted" => {
+        let transaction = winreg::transaction::Transaction::new().unwrap();
+        key.encode_transacted(&v1, &transaction).unwrap();
+        transaction.commit().unwrap();
+        let v2: SomeFields = key.decode().unwrap();
+        assert_eq!(v2, v1);
+    });
+}
+
+#[test]
+fn test_serialization_all_transacted() {
+    let v1 = AllFields::test_val();
+
+    with_key!(key, "SerializationAllTransacted" => {
+        let transaction = winreg::transaction::Transaction::new().unwrap();
+        key.encode_transacted(&v1, &transaction).unwrap();
+        transaction.commit().unwrap();
+        let v2: AllFields = key.decode().unwrap();
+        assert_eq!(v2, v1);
+    });
+}


### PR DESCRIPTION
- The RegKey::encode_transacted allows for encoding a serializable value using an existing transaction
- To make this work, a few changes were made to Encoder and Transaction
- Transaction now implements AsRef<Transaction> which shouldn't change anything
- Encoder now stores a generic AsRef<Transaction> instead of a fully owned Transaction
- This allows for two implementations, one is the existing one that owns the transaction and commits it on drop, the other only has a borrowed transaction that will not cause a commit on drop
- This way an existing transaction can be used
- Also added an example for transacted_serialization