### PR TITLE
bump windows-sys to 0.52.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["api-bindings", "os::windows-apis"]
 
 [dependencies]
 cfg-if = "1.0"
-windows-sys = {version = "0.48.0", features = [
+windows-sys = { version = "0.52.0", features = [
     "Win32_Foundation",
     "Win32_System_Time",
     "Win32_System_Registry",
     "Win32_Security",
     "Win32_Storage_FileSystem",
     "Win32_System_Diagnostics_Debug"
-]}
+] }
 chrono = { version = "0.4.6", optional = true }
 serde = { version = "1", optional = true }
 


### PR DESCRIPTION
Avoid this `#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]` in windows-sys 0.48.0.

The feature `raw_dylib` has been stable since `1.71.0`.